### PR TITLE
Add proxy and target file protection parameters

### DIFF
--- a/lib/puppet/type/download.rb
+++ b/lib/puppet/type/download.rb
@@ -55,4 +55,32 @@ Puppet::Type.newtype(:download) do
   newparam(:pass) do
     desc "A pass to use for basic authentication."
   end
+  
+  newparam(:proxy_uri) do
+    desc "HTTP proxy URL."
+  end
+  
+  newparam(:proxy_user) do
+    desc "A user for proxy authentication."
+  end
+  
+  newparam(:proxy_pass) do
+    desc "A password for proxy authentication."
+  end
+  
+  newparam(:noclobber) do
+    desc "Do not overwrite destination if it exists."
+  end
+  
+  newparam(:owner) do
+    desc "Owner of destination file."
+  end
+  
+  newparam(:group) do
+    desc "Group of destination file."
+  end
+  
+  newparam(:mode) do
+    desc "Mode of destination file."
+  end
 end


### PR DESCRIPTION
Added parameters 'proxy_uri', 'proxy_user' and 'proxy_pass' to support use of HTTP proxy.
Added parameters 'owner', 'group', 'mode' to manage ownership and protection of target file.
Added parameter 'noclobber' to suppress download if target file already exists.
