### PR TITLE
Added Proxy support for http calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ download { 'download with basic auth and ssl, ssl forced':
     user    => 'user',
     pass    => 'pass'
 }
+
+download { 'download with proxy settings without auth':
+    uri         => 'http://host.com:8443/test.txt',
+    dest        => '/tmp/example.txt',
+    proxy_host  => '127.0.0.1',
+    proxy_port  => '3128'
+}
+
+download { 'download with proxy setting with auth':
+    uri         => 'http://host.com:8443/test.txt',
+    dest        => '/tmp/example.txt',
+    proxy_host  => '127.0.0.1',
+    proxy_port  => '3128',
+    proxy_user  => 'my-proxy-user',
+    proxy_pass  => 'my-proxy-pass'
+}
+
 ```
 
 ## Supported OSes

--- a/lib/puppet/provider/download/ruby.rb
+++ b/lib/puppet/provider/download/ruby.rb
@@ -8,7 +8,19 @@ Puppet::Type.type(:download).provide(:ruby) do
   def fetch(uri_str, limit = 10)
     raise ArgumentError, 'Too many HTTP redirects' if limit == 0
     uri = URI(uri_str)
-    http = Net::HTTP.new(uri.host, uri.port)
+    
+
+    if resource[:proxy_host] and resource[:proxy_port]
+      
+      if resource[:proxy_user] and resource[:proxy_pass]
+        http = Net::HTTP.new(uri.host, uri.port, resource[:proxy_host], resource[:proxy_port], resource[:proxy_user], resource[:proxy_pass])
+      else
+        http = Net::HTTP.new(uri.host, uri.port, resource[:proxy_host], resource[:proxy_port])
+      end
+    else
+      http = Net::HTTP.new(uri.host, uri.port)
+    end
+
     begin
       if resource[:use_ssl] or uri_str.start_with? 'https'
         http.use_ssl = true

--- a/lib/puppet/type/download.rb
+++ b/lib/puppet/type/download.rb
@@ -27,11 +27,22 @@ Puppet::Type.newtype(:download) do
           
       Download file using basic authentication:    
         
-        download { 'my sll and basic auth download':
+        download { 'my ssl and basic auth download':
           uri  => 'https://www.example.com/download/example.txt',
           dest => '/tmp/example.txt',
           user => 'user',
           pass => 'pass'
+        }
+
+      Download file using proxy settings:
+
+        download { 'my download behind a proxy':
+          uri         => 'https://www.example.com/download/example.txt',
+          dest        => '/tmp/example.txt',
+          proxy_host  => '127.0.0.1',
+          proxy_port  => '3128',
+          proxy_user  => 'user', # optionnal: only if proxy need authentication 
+          proxy_pass  => 'pass' # optionnal: only if proxy need authentication 
         }
   EOS
 
@@ -75,4 +86,22 @@ Puppet::Type.newtype(:download) do
   newparam(:pass) do
     desc "A pass to use for basic authentication."
   end
+
+  newparam(:proxy_host) do
+    desc "The proxy hostname. Make sure the host exists!"
+  end
+
+  newparam(:proxy_port) do
+    desc "The proxy port. Make sure the port is open!"
+  end
+
+
+  newparam(:proxy_user) do
+    desc "The proxy username. This is an optional parameter"
+  end
+
+  newparam(:proxy_pass) do
+    desc "The proxy password. This is an optional parameter"
+  end
+
 end


### PR DESCRIPTION
I added optional parameters to define a proxy with or without authentication.

Tested on CentOS (6.7) and Windows Server 2008 R2 and it works fine as long the destination folder exists.
