### PR TITLE
If error happens there is a need to raise exception to be noticed

### DIFF
--- a/lib/puppet/provider/download/ruby.rb
+++ b/lib/puppet/provider/download/ruby.rb
@@ -96,8 +96,7 @@ Puppet::Type.type(:download).provide(:ruby) do
   def create
     succ = download()
     if !succ
-      Puppet.crit("HTTP download of '#{resource[:uri]}' failed!")
+      raise "HTTP download of '#{resource[:uri]}' failed!"
     end
-    succ
   end
 end


### PR DESCRIPTION
There is no reason to return any value. Ret. value is not checked. Only exception is meaningful.

See also issue:
"when error happens puppet finishes with success status"
