### PR TITLE
Wrapper around download allows to set ownership and mode of downloaded file

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -1,0 +1,53 @@
+# Type: http_download::download
+#
+# This is wrapper around 'download' that sets ownership and mode of downloaded file
+#
+define http_download::download(
+    $uri = undef,
+    $dest = undef,
+    $backupsuffix = undef,
+    $force = undef,
+    $use_ssl = undef,
+    $user = undef,
+    $pass = undef,
+    $proxy_host = undef,
+    $proxy_port = undef,
+    $proxy_user = undef,
+    $proxy_pass = undef,
+    
+    $owner = undef,
+    $group = undef,
+    $mode = undef,
+    
+) {
+
+  if ($uri == undef) {
+    $urival = $name
+  } else {
+    $urival = $uri
+  }
+
+  download { "$name":
+    uri => $urival,
+    dest => $dest,
+    backupsuffix => $backupsuffix,
+    force => $force,
+    use_ssl => $use_ssl,
+    user => $user,
+    pass => $pass,
+    proxy_host => $proxy_host,
+    proxy_port => $proxy_port,
+    proxy_user => $proxy_user,
+    proxy_pass => $proxy_pass,
+  }
+
+  file { "$name":
+    ensure => file,
+    path => $dest,
+    owner => $owner,
+    group => $group,
+    mode => $mode,
+    require => Download["$name"],
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,4 +30,15 @@ class http_download {
     user => 'test',
     pass => 'Basic_Auth1'
   }
+
+  if $::kernel == 'linux' {
+    http_download::download { 'test change mode':
+      uri  => 'http://www.google.com',
+      dest => "${target}google",
+      owner => 'bin',
+      group => 'bin',
+      mode => '0600'
+    }
+  }
+  
 }


### PR DESCRIPTION
Yet another pull request.

See init.pp to see sample usage

It would be possible to use native ruby to set ownership and mode. But implement it using puppet dsl was easier and IMHO there is no need to deal with OS related differencies (windows - linux).

I didn't tested it on windows. Don't have suitable system but there is standard puppet 'file' resource used, so I believe it should do the job.